### PR TITLE
[FEAT] 필터 URL 쿼리 반영 및 새로고침 유지

### DIFF
--- a/budda/src/components/list/select/filter.jsx
+++ b/budda/src/components/list/select/filter.jsx
@@ -91,9 +91,13 @@ const Ripple = styled.span`
   }
 `;
 
-export default function Filter({ list, width = '120px', onChange }) {
+export default function Filter({
+  list,
+  width = '120px',
+  onChange,
+  selectedValue,
+}) {
   const [isOpen, setIsOpen] = useState(false);
-  const [selectedOption, setSelectedOption] = useState(list[0].name);
   const [ripplePosition, setRipplePosition] = useState(null);
   const [isPressed, setIsPressed] = useState(false);
   const wrapperRef = useRef(null);
@@ -115,7 +119,6 @@ export default function Filter({ list, width = '120px', onChange }) {
   };
 
   const handleOption = (option) => {
-    setSelectedOption(option);
     setIsOpen(false);
     if (onChange) {
       onChange(option); // 선택된 옵션을 외부로 전달
@@ -143,7 +146,7 @@ export default function Filter({ list, width = '120px', onChange }) {
         width={width}
       >
         <FilterText>
-          {selectedOption ||
+          {selectedValue ||
             list[0].apartmentName ||
             list[0].areaForExclusiveUse}
         </FilterText>

--- a/budda/src/components/list/select/filterDuration.jsx
+++ b/budda/src/components/list/select/filterDuration.jsx
@@ -14,6 +14,7 @@ export default function FilterDuration() {
           max={endDate}
           onChange={handleStartDate}
           required
+          value={startDate}
         />
         ~
         <S.DateChoice
@@ -22,6 +23,7 @@ export default function FilterDuration() {
           min={startDate}
           max={today}
           onChange={handleEndDate}
+          value={endDate}
         />
       </S.Du>
     </S.FilterWrapper>

--- a/budda/src/components/list/select/filterList.jsx
+++ b/budda/src/components/list/select/filterList.jsx
@@ -20,15 +20,43 @@ export default function FilterList() {
     handleAptChange,
     handleAreaChange,
     handleOrderType,
+    selectedGu,
+    selectedDong,
+    selectedApt,
+    selectedArea,
+    selectedOrderType,
+    startDate,
+    endDate,
   } = useFilterContext();
 
   return (
     <FilterWrapper>
-      <Filter list={arrayList} onChange={handleOrderType} />
-      <Filter list={guList} onChange={handleGuChange} />
-      <Filter list={filteredDong} onChange={handleDongChange} />
-      <Filter list={aptList} width="240px" onChange={handleAptChange} />
-      <Filter list={areaList} onChange={handleAreaChange} />
+      <Filter
+        list={arrayList}
+        onChange={handleOrderType}
+        selectedValue={selectedOrderType?.name}
+      />
+      <Filter
+        list={guList}
+        onChange={handleGuChange}
+        selectedValue={selectedGu?.name}
+      />
+      <Filter
+        list={filteredDong}
+        onChange={handleDongChange}
+        selectedValue={selectedDong?.name}
+      />
+      <Filter
+        list={aptList}
+        width="240px"
+        onChange={handleAptChange}
+        selectedValue={selectedApt?.apartmentName}
+      />
+      <Filter
+        list={areaList}
+        onChange={handleAreaChange}
+        selectedValue={selectedArea?.areaForExclusiveUse}
+      />
       <FilterDuration />
     </FilterWrapper>
   );

--- a/budda/src/hooks/useTradeList.js
+++ b/budda/src/hooks/useTradeList.js
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useFilterContext } from '../context/FilterContext';
 import api from '../axios';
+import useUrlQuery from './useUrlQuery';
 
 export default function useTradeList() {
   const {
@@ -13,6 +14,15 @@ export default function useTradeList() {
     endDate,
     isDoubt,
     reliability,
+    setSelectedGu,
+    setFilteredDong,
+    setSelectedDong,
+    setSelectedApt,
+    setSelectedArea,
+    setSelectedOrderType,
+    handleStartDate,
+    handleEndDate,
+    handleDoubt,
   } = useFilterContext();
 
   const [pageNum, setPageNum] = useState(1); //리스트 현재 페이지 번호
@@ -45,7 +55,7 @@ export default function useTradeList() {
           reliability: reliability,
           notValid: true,
           order: selectedOrderType.inorder,
-          orderType: selectedGu.eng,
+          orderType: selectedOrderType.eng,
           page: pageNum - 1,
         },
       });
@@ -72,6 +82,39 @@ export default function useTradeList() {
     isDoubt,
     reliability,
   ]);
+
+  useUrlQuery(
+    {
+      gu: selectedGu?.name,
+      dong: selectedDong?.name,
+      apt: selectedApt?.apartmentName,
+      area: selectedArea?.areaForExclusiveUse,
+      order: selectedOrderType?.eng || 'DEAL_DATE',
+      from: startDate || undefined,
+      to: endDate || undefined,
+      rel: reliability,
+    },
+    pageNum,
+    {
+      setSelectedGu,
+      setFilteredDong,
+      setSelectedDong,
+      setSelectedApt,
+      setSelectedArea,
+      setSelectedOrderType,
+      handleStartDate,
+      handleEndDate,
+      handleDoubt,
+      currentReliability: reliability,
+      setPage: setPageNum,
+    },
+    {
+      defaults: { order: 'DEAL_DATE', page: 1 },
+      pushOnPageChange: true,
+      replaceOnFilterChange: true,
+    }
+  );
+
   return {
     aptList,
     load,

--- a/budda/src/hooks/useUrlQuery.js
+++ b/budda/src/hooks/useUrlQuery.js
@@ -1,0 +1,138 @@
+import { useEffect, useMemo, useRef } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
+import { guList, dongList, arrayList } from '../data/data';
+
+export default function useUrlQuery(filters, page, setters, opts = {}) {
+  const {
+    defaults = { order: 'DEAL_DATE', page: 1 },
+    pushOnPageChange = true,
+    replaceOnFilterChange = true,
+  } = opts;
+
+  const {
+    setSelectedGu,
+    setFilteredDong,
+    setSelectedDong,
+    setSelectedApt,
+    setSelectedArea,
+    setSelectedOrderType,
+    handleStartDate,
+    handleEndDate,
+    handleDoubt,
+    currentReliability,
+    setPage,
+  } = setters;
+
+  const nav = useNavigate();
+  const { search } = useLocation();
+  const prev = useRef({ query: '', page });
+
+  useEffect(() => {
+    let effectiveSearch = search;
+    if (!effectiveSearch) {
+      const saved = sessionStorage.getItem('listSearch');
+      if (saved) {
+        effectiveSearch = saved;
+        // URL에도 반영해서 사용자가 돌아왔을 때 동일한 상태로 보이도록
+        nav({ search: saved }, { replace: true });
+      }
+    }
+
+    if (!effectiveSearch) return;
+
+    const q = new URLSearchParams(effectiveSearch);
+    const parsed = {
+      order: q.get('order') || defaults.order,
+      gu: q.get('gu') || undefined,
+      dong: q.get('dong') || undefined,
+      apt: q.get('apt') || undefined,
+      area: q.get('area') || undefined,
+      from: q.get('from') || undefined,
+      to: q.get('to') || undefined,
+      rel: q.get('rel') || 'ALL',
+      page: q.get('page') ? Number(q.get('page')) : defaults.page,
+    };
+
+    if (parsed.gu) {
+      const guObj = guList.find((g) => g.name === parsed.gu) || guList[0];
+      console.log(parsed.gu, guObj);
+      setSelectedGu(guObj);
+
+      const dongsOfGu = dongList.filter((d) => d.guNum === guObj.num);
+      setFilteredDong(dongsOfGu);
+
+      if (parsed.dong) {
+        const dongObj =
+          dongsOfGu.find((d) => d.name === parsed.dong) || dongsOfGu[0];
+        setSelectedDong(dongObj);
+      }
+    }
+
+    if (parsed.order) {
+      const ord =
+        arrayList.find(
+          (o) => o.eng === parsed.order || o.inorder === parsed.order
+        ) || arrayList[0];
+      setSelectedOrderType(ord);
+    }
+
+    if (parsed.apt) setSelectedApt({ apartmentName: parsed.apt });
+    if (parsed.area) setSelectedArea({ areaForExclusiveUse: parsed.area });
+
+    if (parsed.from) handleStartDate({ target: { value: parsed.from } });
+    if (parsed.to) handleEndDate({ target: { value: parsed.to } });
+
+    if (parsed.rel && parsed.rel !== currentReliability) {
+      handleDoubt();
+    }
+
+    if (!Number.isNaN(parsed.page)) setPage(parsed.page);
+  }, []);
+
+  const query = useMemo(() => {
+    const q = new URLSearchParams();
+    const put = (k, v, isDefault = false) => {
+      if (v === undefined || v === null || v === '') return;
+      if (isDefault) return;
+      q.set(k, String(v));
+    };
+
+    put('gu', filters.gu);
+    put('dong', filters.dong);
+    put('apt', filters.apt);
+    put('area', filters.area);
+    put('order', filters.order, filters.order === defaults.order);
+    put('from', filters.from);
+    put('to', filters.to);
+    put('rel', filters.rel);
+    put('page', page, page === defaults.page);
+
+    return q.toString();
+  }, [filters, page, defaults.order, defaults.page]);
+
+  useEffect(() => {
+    const nextSearch = query ? `?${query}` : '';
+    const prevQuery = prev.current.query;
+    const prevPage = prev.current.page;
+
+    const pageChanged = page !== prevPage;
+    const onlyPageChanged =
+      pageChanged && stripPage(prevQuery) === stripPage(query);
+
+    if (pushOnPageChange && onlyPageChanged) {
+      nav({ search: nextSearch }, { replace: false });
+    } else {
+      nav({ search: nextSearch }, { replace: replaceOnFilterChange });
+    }
+
+    prev.current = { query, page };
+    sessionStorage.setItem('listSearch', nextSearch);
+  }, [query, page, nav]);
+
+  function stripPage(qs) {
+    if (!qs) return '';
+    const u = new URLSearchParams(qs);
+    u.delete('page');
+    return u.toString();
+  }
+}


### PR DESCRIPTION
- 필터를 선택할 때 URL 쿼리에 적용되도록 useUrlQuery훅 생성
- ui에도 반영되도록 filter 컴포넌트에도 적용
- filterDuration에도 적용
- useTradeList 훅에서 url 훅을 호출하여 동작하도록 함
- sessionStorage로 다른 페이지에서 다시 접속하여도 필터 선택 정보가 남아있음